### PR TITLE
Add `setuptools` as a runtime requirement

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,7 +10,7 @@ source:
   md5: edb51693fe22c53cee5403775c71a99e
 
 build:
-  number:  0
+  number:  1
   script: python setup.py install --single-version-externally-managed --record=record.txt
 
 requirements:
@@ -20,6 +20,7 @@ requirements:
     - markupsafe
   run:
     - python
+    - setuptools
     - markupsafe
 
 test:


### PR DESCRIPTION
Fixes https://github.com/conda-forge/jinja2-feedstock/issues/3

Appears there are some conditions where `jinja2` may require `setuptools` as a runtime dependency. Please see the linked issue for more details. This fixes that problem by adding `setuptools` as a runtime dependency.

cc @cel4
