### PR TITLE
Update for version 2.9.5

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -7,7 +7,7 @@ package:
 source:
   fn: Jinja2-{{ version }}.tar.gz
   url: https://pypi.io/packages/source/J/Jinja2/Jinja2-{{ version }}.tar.gz
-  md5: 9e55f0db6620dd99a1b366183a94270d
+  sha256: 702a24d992f856fa8d5a7a36db6128198d0c21e1da34448ca236c42e92384825
 
 build:
   number:  0

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version="2.8" %}
+{% set version="2.9.5" %}
 
 package:
   name: jinja2
@@ -7,10 +7,10 @@ package:
 source:
   fn: Jinja2-{{ version }}.tar.gz
   url: https://pypi.io/packages/source/J/Jinja2/Jinja2-{{ version }}.tar.gz
-  md5: edb51693fe22c53cee5403775c71a99e
+  md5: 9e55f0db6620dd99a1b366183a94270d
 
 build:
-  number:  1
+  number:  0
   script: python setup.py install --single-version-externally-managed --record=record.txt
 
 requirements:


### PR DESCRIPTION
Hello everyone,

As mentioned in #7, this is my PR for the update to Jinja 2.9.5. Tests are passing on [all](https://circleci.com/gh/bow/jinja2-feedstock/2) [of the CI](https://ci.appveyor.com/project/bow/jinja2-feedstock) [platforms we use](https://travis-ci.org/bow/jinja2-feedstock/builds/202063353), so I guess this is a good sign?

In any case, would anyone mind checking if everything is in order? I may have missed some things :).

Thanks in advance!