### PR TITLE
Deny python-2 compatibility (retrospectively).

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -13,13 +13,13 @@ source:
 
 build:
   noarch: python
-  number: 0
+  number: 1
   script: python -m pip install --no-deps --ignore-installed .
 
 requirements:
   host:
     - pip
-    - python
+    - python >=3
     - setuptools
 
   run:


### PR DESCRIPTION
I have encountered an integration issue in a project where some dependency is attempting to import 'jinja.async_support' in a Python 2 installation.  
The env was built with conda, and I was really surprised to find Python 3 code in it like that.
It seemed to me that maybe we shouldn't claim to be Python 2 compatible since version 2.9, when this was introduced, in which case the dependency requirements should change.

Other views on that ??

Checklist
* [x] Used a fork of the feedstock to propose changes
* [x] Bumped the build number (if the version is unchanged)
* [x] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

