### PR TITLE
[2.11.x] marginally loosen upper bound for markupsafe

### DIFF
--- a/.ci_support/linux_64_.yaml
+++ b/.ci_support/linux_64_.yaml
@@ -6,9 +6,3 @@ channel_targets:
 - conda-forge main
 docker_image:
 - quay.io/condaforge/linux-anvil-cos7-x86_64
-pin_run_as_build:
-  python:
-    min_pin: x.x
-    max_pin: x.x
-python:
-- 3.9.* *_cpython

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,7 +7,8 @@ version: 2
 jobs:
   build:
     working_directory: ~/test
-    machine: true
+    machine:
+      image: ubuntu-2004:current
     steps:
       - run:
           # The Circle-CI build should not be active, but if this is not true for some reason, do a fast finish.

--- a/.github/workflows/automerge.yml
+++ b/.github/workflows/automerge.yml
@@ -16,3 +16,4 @@ jobs:
         uses: conda-forge/automerge-action@master
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
+          rerendering_github_token: ${{ secrets.RERENDERING_GITHUB_TOKEN }}

--- a/.github/workflows/webservices.yml
+++ b/.github/workflows/webservices.yml
@@ -10,3 +10,4 @@ jobs:
         uses: conda-forge/webservices-dispatch-action@master
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
+          rerendering_github_token: ${{ secrets.RERENDERING_GITHUB_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -48,16 +48,41 @@ conda config --add channels conda-forge
 conda config --set channel_priority strict
 ```
 
-Once the `conda-forge` channel has been enabled, `jinja2` can be installed with:
+Once the `conda-forge` channel has been enabled, `jinja2` can be installed with `conda`:
 
 ```
 conda install jinja2
 ```
 
-It is possible to list all of the versions of `jinja2` available on your platform with:
+or with `mamba`:
+
+```
+mamba install jinja2
+```
+
+It is possible to list all of the versions of `jinja2` available on your platform with `conda`:
 
 ```
 conda search jinja2 --channel conda-forge
+```
+
+or with `mamba`:
+
+```
+mamba search jinja2 --channel conda-forge
+```
+
+Alternatively, `mamba repoquery` may provide more information:
+
+```
+# Search all versions available on your platform:
+mamba repoquery search jinja2 --channel conda-forge
+
+# List packages depending on `jinja2`:
+mamba repoquery whoneeds jinja2 --channel conda-forge
+
+# List dependencies of `jinja2`:
+mamba repoquery depends jinja2 --channel conda-forge
 ```
 
 
@@ -75,10 +100,12 @@ for each of the installable packages. Such a repository is known as a *feedstock
 A feedstock is made up of a conda recipe (the instructions on what and how to build
 the package) and the necessary configurations for automatic building using freely
 available continuous integration services. Thanks to the awesome service provided by
-[CircleCI](https://circleci.com/), [AppVeyor](https://www.appveyor.com/)
-and [TravisCI](https://travis-ci.com/) it is possible to build and upload installable
-packages to the [conda-forge](https://anaconda.org/conda-forge)
-[Anaconda-Cloud](https://anaconda.org/) channel for Linux, Windows and OSX respectively.
+[Azure](https://azure.microsoft.com/en-us/services/devops/), [GitHub](https://github.com/),
+[CircleCI](https://circleci.com/), [AppVeyor](https://www.appveyor.com/),
+[Drone](https://cloud.drone.io/welcome), and [TravisCI](https://travis-ci.com/)
+it is possible to build and upload installable packages to the
+[conda-forge](https://anaconda.org/conda-forge) [Anaconda-Cloud](https://anaconda.org/)
+channel for Linux, Windows and OSX respectively.
 
 To manage the continuous integration and simplify feedstock maintenance
 [conda-smithy](https://github.com/conda-forge/conda-smithy) has been developed.

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -25,7 +25,7 @@ requirements:
   run:
     - python >=3.5
     - setuptools
-    - markupsafe >=0.23
+    - markupsafe >=0.23,<2.1
 
 test:
   imports:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -13,7 +13,7 @@ source:
 
 build:
   noarch: python
-  number: 1
+  number: 2
   script: {{ PYTHON }} -m pip install . --no-deps -vv
 
 requirements:
@@ -25,7 +25,7 @@ requirements:
   run:
     - python >=3.5
     - setuptools
-    - markupsafe >=0.23,<2
+    - markupsafe >=0.23
 
 test:
   imports:


### PR DESCRIPTION
~This does not represent the upstream [bounds](https://github.com/pallets/jinja/blob/2.11.3/setup.py#L53), and leads to resolution errors where things should actually work.~

Edit: see discussion below